### PR TITLE
Remove CBOR encoding of JWK thumbprint (Draft 28)

### DIFF
--- a/app/src/main/java/com/credman/cmwallet/openid4vp/OpenId4VP.kt
+++ b/app/src/main/java/com/credman/cmwallet/openid4vp/OpenId4VP.kt
@@ -179,7 +179,7 @@ class OpenId4VP(
                     listOf(
                         origin,
                         nonce,
-                        cborEncode(ecJwkThumbprintSha256(encryptionJwk!!))
+                        ecJwkThumbprintSha256(encryptionJwk!!)
                     )
                 }
                 else -> throw IllegalArgumentException("Unsupported response mode: $responseMode")


### PR DESCRIPTION
This PR removes the CBOR-encoding of the JWK thumbprint when constructing an instance of `OpenID4VPDCAPIHandoverInfo`. Some ambiguity in Draft 28 led to the thumbprint being inadvertently CBOR-encoded when [the intent was always for the bytes of the hash output to be used as-is](https://github.com/openid/OpenID4VP/issues/591#issuecomment-2859233511).

A [PR I submitted over in the OID4VP repo](https://github.com/openid/OpenID4VP/pull/592) to clear up the ambiguity that led to this behavior has received sufficient support that it seems safe now to apply this change to CMWallet.