### PR TITLE
Add basic skeleton for a Rust based matcher

### DIFF
--- a/matcher-rs/.gitignore
+++ b/matcher-rs/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+/bin/
+pkg/
+wasm-pack.log

--- a/matcher-rs/Cargo.toml
+++ b/matcher-rs/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "matcher-rs"
+version = "0.1.0"
+authors = ["rensiyuan"]
+edition = "2024"
+build = "build.rs"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.145"
+
+[dev-dependencies]
+
+[build-dependencies]
+bindgen = "0.72.1"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+lto = true

--- a/matcher-rs/build.rs
+++ b/matcher-rs/build.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../matcher/credentialmanager.h");
+    println!("cargo:rerun-if-env-changed=TARGET");
+
+    let builder = bindgen::Builder::default()
+        .header("../matcher/credentialmanager.h")
+        .clang_arg("-I/usr/include")
+        .clang_arg("-fvisibility=default")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
+
+    let bindings = builder.generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/matcher-rs/src/bin/issuance.rs
+++ b/matcher-rs/src/bin/issuance.rs
@@ -1,0 +1,19 @@
+use matcher_rs::{
+    credman::{CredmanApi, CredmanApiImpl},
+    internal_start,
+};
+use std::ffi::{CString};
+
+fn main() {
+    if let Err(err) = internal_start() {
+        let mut credman = CredmanApiImpl {};
+        credman.add_string_id_entry(
+            c"Error",
+            None,
+            Some(c"Error"),
+            Some(&CString::new(err.to_string()).unwrap()),
+            None,
+            None,
+        );
+    }
+}

--- a/matcher-rs/src/bindings.rs
+++ b/matcher-rs/src/bindings.rs
@@ -1,0 +1,6 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/matcher-rs/src/credman.rs
+++ b/matcher-rs/src/credman.rs
@@ -1,0 +1,69 @@
+use std::{ffi::CStr, os::raw::c_void};
+
+use crate::bindings::{AddStringIdEntry, GetCredentialsSize, GetRequestBuffer, GetRequestSize, ReadCredentialsBuffer};
+
+pub trait CredmanApi {
+    fn get_request_buffer(&self) -> Vec<u8>;
+    fn get_registered_data(&self) -> Vec<u8>;
+    fn add_string_id_entry(
+        &mut self,
+        entry_id: &CStr,
+        icon: Option<&[u8]>,
+        title: Option<&CStr>,
+        subtitle: Option<&CStr>,
+        disclaimer: Option<&CStr>,
+        warning: Option<&CStr>,
+    );
+}
+
+pub struct CredmanApiImpl;
+
+impl CredmanApi for CredmanApiImpl {
+    fn get_request_buffer(&self) -> Vec<u8> {
+        let mut size: u32 = 0;
+        unsafe {
+            GetRequestSize(&mut size);
+        }
+        let mut r = Vec::new();
+        r.resize(size as usize, 0);
+        unsafe {
+            GetRequestBuffer(r.as_mut_ptr() as *mut c_void);
+        }
+        return r;
+    }
+    fn get_registered_data(&self) -> Vec<u8> {
+        let mut size: u32 = 0;
+        unsafe {
+            GetCredentialsSize(&mut size);
+        }
+        let mut r = Vec::new();
+        r.resize(size.try_into().unwrap(), 0);
+        unsafe {
+            ReadCredentialsBuffer(r.as_mut_ptr() as *mut c_void, 0, size as usize);
+        }
+        return r;
+    }
+    fn add_string_id_entry(
+        &mut self,
+        entry_id: &CStr,
+        icon: Option<&[u8]>,
+        title: Option<&CStr>,
+        subtitle: Option<&CStr>,
+        disclaimer: Option<&CStr>,
+        warning: Option<&CStr>,
+    ) {
+        let icon_bytes = icon.map_or(std::ptr::null(), |x| x.as_ptr()) as *const i8;
+        let icon_length = icon.map_or(0, |x| x.len());
+        unsafe {
+            AddStringIdEntry(
+                entry_id.as_ptr(),
+                icon_bytes,
+                icon_length,
+                title.map_or(std::ptr::null(), |x| x.as_ptr()),
+                subtitle.map_or(std::ptr::null(), |x| x.as_ptr()),
+                disclaimer.map_or(std::ptr::null(), |x| x.as_ptr()),
+                warning.map_or(std::ptr::null(), |x| x.as_ptr()),
+            );
+        }
+    }
+}

--- a/matcher-rs/src/lib.rs
+++ b/matcher-rs/src/lib.rs
@@ -1,0 +1,8 @@
+mod bindings;
+pub mod credman;
+
+
+pub fn internal_start() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+

--- a/matcher/credentialmanager.h
+++ b/matcher/credentialmanager.h
@@ -8,51 +8,54 @@
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddEntry")))
 #endif
-void AddEntry(long long cred_id, char* icon, size_t icon_len, char *title, char *subtitle, char *disclaimer, char *warning);
+void AddEntry(long long cred_id, const char* icon, size_t icon_len, const char* title, const char* subtitle, const char* disclaimer, const char* warning);
 
 // Deprecated. Use AddFieldForStringIdEntry instead.
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddField")))
 #endif
-void AddField(long long cred_id, char *field_display_name, char *field_display_value);
+void AddField(long long cred_id, const char* field_display_name, const char* field_display_value);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman_v2"), import_name("AddEntrySet")))
 #endif
-void AddEntrySet(char *set_id, int set_length);
+void AddEntrySet(const char* set_id, int set_length);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman_v2"), import_name("AddEntryToSet")))
 #endif
-void AddEntryToSet(char *cred_id, char* icon, size_t icon_len, char *title, char *subtitle, char *disclaimer, char *warning, char *metadata, char *set_id, int set_index);
+void AddEntryToSet(const char* cred_id, const char* icon, size_t icon_len, const char* title, const char* subtitle, const char* disclaimer, const char* warning, const char* metadata, const char* set_id, int set_index);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman_v2"), import_name("AddFieldToEntrySet")))
 #endif
-void AddFieldToEntrySet(char *cred_id, char *field_display_name, char *field_display_value, char *set_id, int set_index);
+void AddFieldToEntrySet(const char* cred_id, const char* field_display_name, const char* field_display_value, const char* set_id, int set_index);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman_v2"), import_name("AddPaymentEntryToSet")))
 #endif
-void AddPaymentEntryToSet(char *cred_id, char *merchant_name, char *payment_method_name, char *payment_method_subtitle, char* payment_method_icon, size_t payment_method_icon_len, char *transaction_amount, char* bank_icon, size_t bank_icon_len, char* payment_provider_icon, size_t payment_provider_icon_len, char *metadata, char *set_id, int set_index);
+void AddPaymentEntryToSet(const char* cred_id, const char* merchant_name, const char* payment_method_name, const char* payment_method_subtitle, const char* payment_method_icon, size_t payment_method_icon_len, const char* transaction_amount, const char* bank_icon, size_t bank_icon_len, const char* payment_provider_icon, size_t payment_provider_icon_len, const char* metadata, const char* set_id, int set_index);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman_v2"), import_name("AddPaymentEntryToSetV2")))
 #endif
-void AddPaymentEntryToSetV2(char *cred_id, char *merchant_name, char *payment_method_name, char *payment_method_subtitle, char* payment_method_icon, size_t payment_method_icon_len, char *transaction_amount, char* bank_icon, size_t bank_icon_len, char* payment_provider_icon, size_t payment_provider_icon_len, char *additional_info, char *metadata, char *set_id, int set_index);
+void AddPaymentEntryToSetV2(const char* cred_id, const char* merchant_name, const char* payment_method_name, const char* payment_method_subtitle, const char* payment_method_icon, size_t payment_method_icon_len, const char* transaction_amount, const char* bank_icon, size_t bank_icon_len, const char* payment_provider_icon, size_t payment_provider_icon_len, const char* additional_info, const char* metadata, const char* set_id, int set_index);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddStringIdEntry")))
 #endif
-void AddStringIdEntry(char *cred_id, char* icon, size_t icon_len, char *title, char *subtitle, char *disclaimer, char *warning);
+void AddStringIdEntry(const char* cred_id, const char* icon, size_t icon_len, const char* title, const char* subtitle, const char* disclaimer, const char* warning);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddFieldForStringIdEntry")))
 #endif
-void AddFieldForStringIdEntry(char *cred_id, char *field_display_name, char *field_display_value);
+void AddFieldForStringIdEntry(const char* cred_id, const char* field_display_name, const char* field_display_value);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("GetRequestBuffer")))
+#endif
+#if defined(__rust_bindgen__)
+__attribute__ ((visibility("default")))
 #endif
 void GetRequestBuffer(void* buffer);
 
@@ -79,17 +82,17 @@ void GetWasmVersion(uint32_t* version);
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddPaymentEntry")))
 #endif
-void AddPaymentEntry(char *cred_id, char *merchant_name, char *payment_method_name, char *payment_method_subtitle, char* payment_method_icon, size_t payment_method_icon_len, char *transaction_amount, char* bank_icon, size_t bank_icon_len, char* payment_provider_icon, size_t payment_provider_icon_len);
+void AddPaymentEntry(const char* cred_id, const char* merchant_name, const char* payment_method_name, const char* payment_method_subtitle, const char* payment_method_icon, size_t payment_method_icon_len, const char* transaction_amount, const char* bank_icon, size_t bank_icon_len, const char* payment_provider_icon, size_t payment_provider_icon_len);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("AddInlineIssuanceEntry")))
 #endif
-void AddInlineIssuanceEntry(char *cred_id, char* icon, size_t icon_len, char *title, char *subtitle);
+void AddInlineIssuanceEntry(const char* cred_id, const char* icon, size_t icon_len, const char* title, const char* subtitle);
 
 #if defined(__wasm__)
 __attribute__((import_module("credman"), import_name("SetAdditionalDisclaimerAndUrlForVerificationEntry")))
 #endif
-void SetAdditionalDisclaimerAndUrlForVerificationEntry(char *cred_id, char *secondary_disclaimer, char *url_display_text, char *url_value);
+void SetAdditionalDisclaimerAndUrlForVerificationEntry(const char* cred_id, const char* secondary_disclaimer, const char* url_display_text, const char* url_value);
 
 typedef struct CallingAppInfo {
 	char package_name[256];
@@ -106,6 +109,6 @@ void GetCallingAppInfo(CallingAppInfo* info);
 #if defined(__wasm__)
 __attribute__((import_module("credman_v4"), import_name("SelfDeclarePackageInfo")))
 #endif
-void SelfDeclarePackageInfo(char *package_display_name, char* package_icon, size_t package_icon_len);
+void SelfDeclarePackageInfo(const char* package_display_name, const char* package_icon, size_t package_icon_len);
 
 #endif 

--- a/matcher/testharness.c
+++ b/matcher/testharness.c
@@ -36,10 +36,10 @@ size_t ReadCredentialsBuffer(void* buffer, size_t offset, size_t len) {
     return bytes_read;
 }
 
-void AddStringIdEntry(char *cred_id, char* icon, size_t icon_len, char *title, char *subtitle, char *disclaimer, char *warning) {
+void AddStringIdEntry(const char* cred_id, const char* icon, size_t icon_len, const char* title, const char* subtitle, const char* disclaimer, const char* warning) {
     printf("AddStringIdEntry id:%s title:%s subtitle:%s\n", cred_id, title, subtitle);
 }
 
-void AddFieldForStringIdEntry(char *cred_id, char *field_display_name, char *field_display_value) {
+void AddFieldForStringIdEntry(const char* cred_id, const char* field_display_name, const char* field_display_value) {
     printf("AddFieldForStringIdEntry id:%s field_display_name:%s\n", cred_id, field_display_name);
 }


### PR DESCRIPTION
This sets up the binding generation and source file organization for a Rust based matcher. Actually functionality will come in future PRs.