### PR TITLE
Optimize the binary size of matcher-rs

### DIFF
--- a/matcher-rs/Cargo.lock
+++ b/matcher-rs/Cargo.lock
@@ -85,12 +85,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,8 +130,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "lol_alloc",
- "serde",
- "serde_json",
+ "nanoserde",
 ]
 
 [[package]]
@@ -151,6 +144,21 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nanoserde"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de9cf844ab1e25a0353525bd74cb889843a6215fa4a0d156fd446f4857a1b99"
+dependencies = [
+ "nanoserde-derive",
+]
+
+[[package]]
+name = "nanoserde-derive"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e943b2c21337b7e3ec6678500687cdc741b7639ad457f234693352075c082204"
 
 [[package]]
 name = "nom"
@@ -226,59 +234,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.145"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "shlex"

--- a/matcher-rs/Cargo.toml
+++ b/matcher-rs/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 lol_alloc = "0.4.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.145"
+nanoserde = "0.1"
 
 [dev-dependencies]
 

--- a/matcher-rs/build.sh
+++ b/matcher-rs/build.sh
@@ -1,0 +1,16 @@
+# 1. Build with maximum rustc optimizations
+CARGO_PROFILE_RELEASE_PANIC=immediate-abort \
+CARGO_PROFILE_RELEASE_OPT_LEVEL="z" \
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+CARGO_PROFILE_RELEASE_STRIP=true \
+cargo +nightly build \
+  -Z panic-immediate-abort \
+  -Z build-std \
+  --target wasm32-unknown-unknown \
+  --release
+
+# 2. Further shrink using wasm-opt (if available)
+wasm-opt -Oz --strip-debug --enable-bulk-memory \
+  target/wasm32-unknown-unknown/release/issuance.wasm \
+  -o target/wasm32-unknown-unknown/release/issuance.wasm
+

--- a/matcher-rs/src/issuance.rs
+++ b/matcher-rs/src/issuance.rs
@@ -315,63 +315,36 @@ mod test {
   "entry_id": "C",
   "title": "TTTT",
   "subtitle": "SSSSS",
-  "icon": [0, 0],
+  "icon": [
+    0,
+    0
+  ],
   "filter": {
-    "SupportsMdocDoctype": {
-      "doctypes": ["org.iso.18013.5.1.mDL"]
-    }
-  }
-}"#,
-            icon: Vec::new(),
-            added_entries: Vec::new(),
-        };
-
-        issuance_main(&mut credman).unwrap();
-
-        assert_eq!(credman.added_entries.len(), 1);
-    }
-
-    #[test]
-    fn match_mdoc_with_algs() {
-        let mut credman = FakeCredman {
-            request_json: r#"
-{
-  "requests": [
-    {
-      "protocol": "openid4vci-1.1",
-      "data": {
-        "credential_offer": {
-          "credential_issuer": "https://issuer.my",
-          "credential_configuration_ids": [
-            "FICTITIOUS_STATE_MDL"
-          ],
-          "grants": {
-            "authorization_code": {}
+    "Or": {
+      "filters": [
+        {
+          "AllowsConfigurationIds": {
+            "configuration_ids": [
+              "US_SOCIAL_SECURITY_NUMBER",
+              "EU_AGE"
+            ]
           }
         },
-        "credential_issuer_metadata": {
-          "nonce_endpoint": "https://nonce.my",
-          "credential_configurations_supported": {
-            "FICTITIOUS_STATE_MDL": {
-              "format": "mso_mdoc",
-              "doctype": "org.iso.18013.5.1.mDL",
-              "credential_signing_alg_values_supported": ["ES256", "ES384"]
-            }
+        {
+          "AllowsIssuers": {
+            "issuers": [
+              "ccb"
+            ]
+          }
+        },
+        {
+          "SupportsMdocDoctype": {
+            "doctypes": [
+              "org.iso.18013.5.1.mDL"
+            ]
           }
         }
-      }
-    }
-  ]
-}"#,
-            registered_json: r#"
-{
-  "entry_id": "C",
-  "title": "TTTT",
-  "subtitle": "SSSSS",
-  "icon": [0, 0],
-  "filter": {
-    "SupportsMdocDoctype": {
-      "doctypes": ["org.iso.18013.5.1.mDL"]
+      ]
     }
   }
 }"#,

--- a/matcher-rs/src/issuance.rs
+++ b/matcher-rs/src/issuance.rs
@@ -1,8 +1,12 @@
+use std::ffi::CString;
+
 use crate::{
     credman::CredmanApi,
     issuance_matcher::IssuanceMatcherData,
     openid4vci::{DigitalCredentialCreationRequest, RegularizedOpenId4VciRequestData},
 };
+
+use nanoserde::DeJson;
 
 const ALLOWED_PROTOCOLS: [&str; 4] = [
     "openid4vci-1.0",
@@ -14,10 +18,11 @@ const ALLOWED_PROTOCOLS: [&str; 4] = [
 pub fn issuance_main(credman: &mut impl CredmanApi) -> Result<(), Box<dyn std::error::Error>> {
     let matcher_data_buffer = credman.get_registered_data();
     let json_start = u32::from_le_bytes(matcher_data_buffer[..size_of::<u32>()].try_into()?);
-    let matcher_data: IssuanceMatcherData =
-        serde_json::from_slice(&matcher_data_buffer[json_start.try_into()?..])?;
+    let matcher_data: IssuanceMatcherData = DeJson::deserialize_json(std::str::from_utf8(
+        &matcher_data_buffer[json_start.try_into()?..],
+    )?)?;
     let request: DigitalCredentialCreationRequest =
-        serde_json::from_slice(&credman.get_request_buffer())?;
+        DeJson::deserialize_json(std::str::from_utf8(&credman.get_request_buffer())?)?;
     if request.requests.iter().any(|r| {
         ALLOWED_PROTOCOLS.iter().any(|s| r.protocol == *s)
             && matcher_data
@@ -25,11 +30,20 @@ pub fn issuance_main(credman: &mut impl CredmanApi) -> Result<(), Box<dyn std::e
                 .matches(&RegularizedOpenId4VciRequestData::from(&r.data))
     }) {
         let icon = &matcher_data_buffer[matcher_data.icon.0..matcher_data.icon.1];
+        let entry_id = CString::new(matcher_data.entry_id)?;
+        let title = matcher_data
+            .title
+            .map(|s| CString::new(s))
+            .transpose()?;
+        let subtitle = matcher_data
+            .subtitle
+            .map(|s| CString::new(s))
+            .transpose()?;
         credman.add_string_id_entry(
-            matcher_data.entry_id.as_c_str(),
+            &entry_id,
             if icon.is_empty() { None } else { Some(icon) },
-            matcher_data.title.as_deref(),
-            matcher_data.subtitle.as_deref(),
+            title.as_deref(),
+            subtitle.as_deref(),
             None,
             None,
         );
@@ -188,7 +202,7 @@ mod test {
         };
 
         let errmsg = format!("{:?}", issuance_main(&mut credman).unwrap_err());
-        assert!(errmsg.contains("EOF while parsing an object"));
+        assert!(errmsg.contains("Unexpected token Eof") || errmsg.contains("Unexpected end of file"));
     }
 
     #[test]
@@ -301,36 +315,63 @@ mod test {
   "entry_id": "C",
   "title": "TTTT",
   "subtitle": "SSSSS",
-  "icon": [
-    0,
-    0
-  ],
+  "icon": [0, 0],
   "filter": {
-    "Or": {
-      "filters": [
-        {
-          "AllowsConfigurationIds": {
-            "configuration_ids": [
-              "US_SOCIAL_SECURITY_NUMBER",
-              "EU_AGE"
-            ]
+    "SupportsMdocDoctype": {
+      "doctypes": ["org.iso.18013.5.1.mDL"]
+    }
+  }
+}"#,
+            icon: Vec::new(),
+            added_entries: Vec::new(),
+        };
+
+        issuance_main(&mut credman).unwrap();
+
+        assert_eq!(credman.added_entries.len(), 1);
+    }
+
+    #[test]
+    fn match_mdoc_with_algs() {
+        let mut credman = FakeCredman {
+            request_json: r#"
+{
+  "requests": [
+    {
+      "protocol": "openid4vci-1.1",
+      "data": {
+        "credential_offer": {
+          "credential_issuer": "https://issuer.my",
+          "credential_configuration_ids": [
+            "FICTITIOUS_STATE_MDL"
+          ],
+          "grants": {
+            "authorization_code": {}
           }
         },
-        {
-          "AllowsIssuers": {
-            "issuers": [
-              "ccb"
-            ]
-          }
-        },
-        {
-          "SupportsMdocDoctype": {
-            "doctypes": [
-              "org.iso.18013.5.1.mDL"
-            ]
+        "credential_issuer_metadata": {
+          "nonce_endpoint": "https://nonce.my",
+          "credential_configurations_supported": {
+            "FICTITIOUS_STATE_MDL": {
+              "format": "mso_mdoc",
+              "doctype": "org.iso.18013.5.1.mDL",
+              "credential_signing_alg_values_supported": ["ES256", "ES384"]
+            }
           }
         }
-      ]
+      }
+    }
+  ]
+}"#,
+            registered_json: r#"
+{
+  "entry_id": "C",
+  "title": "TTTT",
+  "subtitle": "SSSSS",
+  "icon": [0, 0],
+  "filter": {
+    "SupportsMdocDoctype": {
+      "doctypes": ["org.iso.18013.5.1.mDL"]
     }
   }
 }"#,

--- a/matcher-rs/src/issuance_matcher.rs
+++ b/matcher-rs/src/issuance_matcher.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashSet, ffi::CString};
+use std::collections::HashSet;
 
-use serde::Deserialize;
+use nanoserde::DeJson;
 
 use crate::openid4vci::RegularizedOpenId4VciRequestData;
 
-#[derive(Deserialize, Debug)]
+#[derive(DeJson, Debug)]
 pub enum OpenId4VciFilter {
     Unit {}, // A placeholder that always matches
     And { filters: Vec<OpenId4VciFilter> },
@@ -79,12 +79,12 @@ impl OpenId4VciFilter {
     }
 }
 
-#[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[derive(DeJson, Debug, Default)]
+#[nserde(default)]
 pub struct IssuanceMatcherData {
-    pub entry_id: CString,
+    pub entry_id: String,
     pub icon: (usize, usize),
-    pub title: Option<CString>,
-    pub subtitle: Option<CString>,
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
     pub filter: OpenId4VciFilter,
 }

--- a/matcher-rs/src/openid4vci.rs
+++ b/matcher-rs/src/openid4vci.rs
@@ -1,22 +1,22 @@
 #![allow(unused)]
 
-use serde::Deserialize;
+use nanoserde::DeJson;
 
-#[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[derive(DeJson, Debug, Default)]
+#[nserde(default)]
 pub struct DigitalCredentialCreationRequest {
     pub requests: Vec<OpenId4VciRequest>,
 }
 
-#[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[derive(DeJson, Debug, Default)]
+#[nserde(default)]
 pub struct OpenId4VciRequest {
     pub protocol: String,
     pub data: OpenId4VciRequestData,
 }
 
-#[derive(Deserialize, Debug, Default)]
-#[serde(default)]
+#[derive(DeJson, Debug, Default)]
+#[nserde(default)]
 pub struct OpenId4VciRequestData {
     pub credential_offer: credential_offer::CredentialOffer,
     pub credential_issuer_metadata: Option<credential_issuer_metadata::CredentialIssuerMetadata>,
@@ -57,28 +57,28 @@ impl<'a> From<&'a OpenId4VciRequestData> for RegularizedOpenId4VciRequestData<'a
 }
 
 pub mod credential_offer {
-    use serde::Deserialize;
+    use nanoserde::DeJson;
     use std::collections::HashMap;
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct CredentialOffer {
         pub credential_issuer: String,
         pub credential_configuration_ids: Vec<String>,
         pub grants: HashMap<String, Grant>,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct Grant {}
 }
 
 mod credential_issuer_metadata {
-    use serde::Deserialize;
+    use nanoserde::DeJson;
     use std::collections::{HashMap, HashSet};
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct CredentialIssuerMetadata {
         // pub credential_issuer: String,
         // pub authorization_servers: Option<Vec<String>>,
@@ -93,17 +93,17 @@ mod credential_issuer_metadata {
         pub credential_configurations_supported: HashMap<String, CredentialConfiguration>,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct CredentialRequestEncryption {
-        // pub jwks: serde_json::Value,
+        // pub jwks: nanoserde::DeJson, // nanoserde doesn't have a Value type
         pub enc_values_supported: HashSet<String>,
         // pub zip_values_supported: Option<Vec<String>>,
         pub encryption_required: bool,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct CredentialResponseEncryption {
         pub alg_values_supported: HashSet<String>,
         pub enc_values_supported: HashSet<String>,
@@ -111,58 +111,48 @@ mod credential_issuer_metadata {
         pub encryption_required: bool,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct BatchCredentialIssuance {
         pub batch_size: u32,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct Display {
         pub name: String,
         pub locale: String,
         pub logo: Option<Logo>,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct Logo {
         pub uri: String,
         pub alt_text: String,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct CredentialConfiguration {
         pub format: String,
         pub scope: String,
         pub doctype: String,
         pub vct: String,
-        pub credential_signing_alg_values_supported: SiginingAlgs,
+        pub credential_signing_alg_values_supported: Vec<String>,
         pub cryptographic_binding_methods_supported: Option<Vec<String>>,
         pub proof_types_supported: HashMap<String, ProofType>,
     }
 
-    #[derive(Deserialize, Debug)]
-    #[serde(untagged)]
-    #[derive(Default)]
-    pub enum SiginingAlgs {
-        #[default]
-        Unspecified,
-        SringAlgs(Vec<String>),
-        IntAlgs(Vec<i32>),
-    }
-
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct ProofType {
         pub proof_signing_alg_values_supported: Vec<String>,
         pub key_attestations_required: Option<KeyAttestationsRequired>,
     }
 
-    #[derive(Deserialize, Debug, Default)]
-    #[serde(default)]
+    #[derive(DeJson, Debug, Default)]
+    #[nserde(default)]
     pub struct KeyAttestationsRequired {
         pub key_storage: Option<Vec<String>>,
         pub user_authentication: Option<Vec<String>>,


### PR DESCRIPTION
Reduce the binary size by switching to `nanoserde` and also add a script to further reduce size by `panic = immediate-abort`