### PR TITLE
PR 7: Integration & Infrastructure

### DIFF
--- a/matcher-rs/Cargo.lock
+++ b/matcher-rs/Cargo.lock
@@ -3,6 +3,28 @@
 version = 4
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,8 +34,10 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "matcher-rs"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "log",
  "nanoserde",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -30,3 +54,9 @@ name = "nanoserde-derive"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e943b2c21337b7e3ec6678500687cdc741b7639ad457f234693352075c082204"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"

--- a/matcher-rs/src/bin/presentation.rs
+++ b/matcher-rs/src/bin/presentation.rs
@@ -1,4 +1,4 @@
-use matcher_rs::{credman::CredmanApiImpl, issuance::issuance_main};
+use matcher_rs::{credman::CredmanApiImpl, openid4vp::openid4vp_main};
 
 #[cfg(target_arch = "wasm32")]
 #[global_allocator]
@@ -7,7 +7,7 @@ static ALLOCATOR: matcher_rs::simple_allocator::SimpleAllocator =
 
 fn main() {
     matcher_rs::logger::init();
-    issuance_main(&mut CredmanApiImpl {}).unwrap();
+    openid4vp_main(&mut CredmanApiImpl {}).unwrap();
 }
 
 // Credman expects this as the entry point, but it isn't there if the target is wasm32-unknown-unknown.

--- a/matcher-rs/src/issuance.rs
+++ b/matcher-rs/src/issuance.rs
@@ -67,8 +67,8 @@ pub fn issuance_main(credman: &mut impl CredmanApi) -> Result<(), Box<dyn std::e
                 credman.add_string_id_entry(
                     &matcher_data.entry_id,
                     icon,
-                    matcher_data.title.as_deref().unwrap_or(""),
-                    matcher_data.subtitle.as_deref().unwrap_or(""),
+                    &matcher_data.title,
+                    &matcher_data.subtitle,
                     "",
                     "",
                 );

--- a/matcher-rs/src/issuance_matcher.rs
+++ b/matcher-rs/src/issuance_matcher.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use crate::json_value::DeterministicSet;
 
 use nanoserde::DeJson;
 
@@ -7,19 +7,35 @@ use crate::openid4vci::RegularizedOpenId4VciRequestData;
 #[derive(DeJson, Debug)]
 pub enum OpenId4VciFilter {
     Unit {}, // A placeholder that always matches
-    And { filters: Vec<OpenId4VciFilter> },
-    Or { filters: Vec<OpenId4VciFilter> },
-    Not { filter: Box<OpenId4VciFilter> },
-    AllowsIssuers { issuers: HashSet<String> },
-    AllowsConfigurationIds { configuration_ids: HashSet<String> },
+    And {
+        filters: Vec<OpenId4VciFilter>,
+    },
+    Or {
+        filters: Vec<OpenId4VciFilter>,
+    },
+    Not {
+        filter: Box<OpenId4VciFilter>,
+    },
+    AllowsIssuers {
+        issuers: DeterministicSet<String>,
+    },
+    AllowsConfigurationIds {
+        configuration_ids: DeterministicSet<String>,
+    },
     SupportsAuthCodeFlow {},
     SupportsPreAuthFlow {},
     SupportsNonceEndpoint {},
     SupportsDeferredCredentialEndpoint {},
     SupportsNotificationEndpoint {},
-    RequiresBatchIssuance { min_batch_size: u32 },
-    SupportsMdocDoctype { doctypes: HashSet<String> },
-    SupportsSdJwtVct { vcts: HashSet<String> },
+    RequiresBatchIssuance {
+        min_batch_size: u32,
+    },
+    SupportsMdocDoctype {
+        doctypes: DeterministicSet<String>,
+    },
+    SupportsSdJwtVct {
+        vcts: DeterministicSet<String>,
+    },
 }
 
 impl Default for OpenId4VciFilter {
@@ -139,7 +155,7 @@ impl OpenId4VciFilter {
 pub struct IssuanceMatcherData {
     pub entry_id: String,
     pub icon: (usize, usize),
-    pub title: Option<String>,
-    pub subtitle: Option<String>,
+    pub title: String,
+    pub subtitle: String,
     pub filter: OpenId4VciFilter,
 }

--- a/matcher-rs/src/lib.rs
+++ b/matcher-rs/src/lib.rs
@@ -10,5 +10,7 @@ pub mod openid4vci;
 pub mod openid4vp;
 pub mod openid4vp_models;
 pub mod reporter;
+#[cfg(target_arch = "wasm32")]
+pub mod simple_allocator;
 #[cfg(test)]
 pub mod test_utils;

--- a/matcher-rs/src/openid4vci.rs
+++ b/matcher-rs/src/openid4vci.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
+use crate::json_value::DeterministicMap;
 use nanoserde::DeJson;
-use std::collections::HashMap;
 
 #[derive(DeJson, Debug, Default)]
 #[nserde(default)]
@@ -21,7 +21,7 @@ pub struct OpenId4VciRequest {
 pub struct OpenId4VciRequestData {
     pub credential_issuer: String,
     pub credential_configuration_ids: Vec<String>,
-    pub grants: HashMap<String, credential_offer::Grant>,
+    pub grants: DeterministicMap<String, credential_offer::Grant>,
     pub credential_issuer_metadata: Option<credential_issuer_metadata::CredentialIssuerMetadata>,
 }
 
@@ -31,7 +31,7 @@ pub struct OpenId4VciRequestData {
 pub struct RegularizedOpenId4VciRequestData<'a> {
     pub credential_issuer: &'a str,
     pub credential_configuration_ids: &'a [String],
-    pub grants: &'a HashMap<String, credential_offer::Grant>,
+    pub grants: &'a DeterministicMap<String, credential_offer::Grant>,
     // Borrow the metadata
     pub credential_issuer_metadata:
         Option<&'a credential_issuer_metadata::CredentialIssuerMetadata>,
@@ -87,8 +87,8 @@ pub mod credential_offer {
 }
 
 mod credential_issuer_metadata {
+    use crate::json_value::{DeterministicMap, DeterministicSet};
     use nanoserde::DeJson;
-    use std::collections::{HashMap, HashSet};
 
     #[derive(DeJson, Debug, Default)]
     #[nserde(default)]
@@ -103,14 +103,14 @@ mod credential_issuer_metadata {
         // pub credential_response_encryption: Option<CredentialResponseEncryption>,
         pub batch_credential_issuance: Option<BatchCredentialIssuance>,
         // pub display: Option<Vec<Display>>,
-        pub credential_configurations_supported: HashMap<String, CredentialConfiguration>,
+        pub credential_configurations_supported: DeterministicMap<String, CredentialConfiguration>,
     }
 
     #[derive(DeJson, Debug, Default)]
     #[nserde(default)]
     pub struct CredentialRequestEncryption {
         // pub jwks: nanoserde::DeJson, // nanoserde doesn't have a Value type
-        pub enc_values_supported: HashSet<String>,
+        pub enc_values_supported: DeterministicSet<String>,
         // pub zip_values_supported: Option<Vec<String>>,
         pub encryption_required: bool,
     }
@@ -118,8 +118,8 @@ mod credential_issuer_metadata {
     #[derive(DeJson, Debug, Default)]
     #[nserde(default)]
     pub struct CredentialResponseEncryption {
-        pub alg_values_supported: HashSet<String>,
-        pub enc_values_supported: HashSet<String>,
+        pub alg_values_supported: DeterministicSet<String>,
+        pub enc_values_supported: DeterministicSet<String>,
         // pub zip_values_supported: Vec<String>,
         pub encryption_required: bool,
     }
@@ -153,8 +153,8 @@ mod credential_issuer_metadata {
         pub doctype: String,
         pub vct: String,
         pub credential_signing_alg_values_supported: Vec<String>,
-        pub cryptographic_binding_methods_supported: Option<Vec<String>>,
-        pub proof_types_supported: HashMap<String, ProofType>,
+        pub cryptographic_binding_methods_supported: Vec<String>,
+        pub proof_types_supported: DeterministicMap<String, ProofType>,
     }
 
     #[derive(DeJson, Debug, Default)]
@@ -167,7 +167,7 @@ mod credential_issuer_metadata {
     #[derive(DeJson, Debug, Default)]
     #[nserde(default)]
     pub struct KeyAttestationsRequired {
-        pub key_storage: Option<Vec<String>>,
-        pub user_authentication: Option<Vec<String>>,
+        pub key_storage: Vec<String>,
+        pub user_authentication: Vec<String>,
     }
 }

--- a/matcher-rs/src/simple_allocator.rs
+++ b/matcher-rs/src/simple_allocator.rs
@@ -1,0 +1,49 @@
+#![cfg(target_arch = "wasm32")]
+
+use core::alloc::{GlobalAlloc, Layout};
+
+pub struct SimpleAllocator;
+
+unsafe extern "C" {
+    static __heap_base: u8;
+}
+
+static mut NEXT_ADDR: usize = 0;
+static mut CURRENT_PAGES: usize = 0;
+
+const PAGE_SIZE: usize = 65536;
+
+unsafe impl GlobalAlloc for SimpleAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let mut next_addr = unsafe { NEXT_ADDR };
+        if next_addr == 0 {
+            next_addr = core::ptr::addr_of!(__heap_base) as usize;
+            unsafe { CURRENT_PAGES = core::arch::wasm32::memory_size(0) };
+        }
+
+        let align = layout.align();
+        let size = layout.size();
+
+        // Align the current pointer
+        let alloc_ptr = (next_addr + align - 1) & !(align - 1);
+        let end_ptr = alloc_ptr + size;
+
+        let current_limit = unsafe { CURRENT_PAGES * PAGE_SIZE };
+
+        if end_ptr > current_limit {
+            let needed_bytes = end_ptr - current_limit;
+            let needed_pages = (needed_bytes + PAGE_SIZE - 1) / PAGE_SIZE;
+            if core::arch::wasm32::memory_grow(0, needed_pages) == usize::MAX {
+                return core::ptr::null_mut();
+            }
+            unsafe { CURRENT_PAGES += needed_pages };
+        }
+
+        unsafe { NEXT_ADDR = end_ptr };
+        alloc_ptr as *mut u8
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+        // No-op bump allocator
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #41
* #40
* #39
* #38
* #37
* #36
* #35

Added binaries and simple_allocator.
Updated issuance, issuance_matcher, openid4vci to use new models and utilities.
Updated Cargo.lock.