### PR TITLE
wasm-opt is changing the semantics when tested on Credential Manager

### DIFF
--- a/matcher-rs/build.sh
+++ b/matcher-rs/build.sh
@@ -10,8 +10,5 @@ cargo +nightly build \
   --target wasm32-unknown-unknown \
   --release
 
-# 2. Further shrink using wasm-opt (if available)
-for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
-  wasm-opt -Oz --strip-debug --enable-bulk-memory --enable-sign-ext --enable-nontrapping-float-to-int "$wasm" -o "$wasm"
-done
+
 


### PR DESCRIPTION
wasm-opt is changing the semantics when tested on Credential Manager, so we have to remove it from the build script