### PR TITLE
Port multi-protocol preference-ordered matching to Rust matcher

### DIFF
--- a/matcher-rs/src/openid4vp.rs
+++ b/matcher-rs/src/openid4vp.rs
@@ -103,18 +103,31 @@ pub fn openid4vp_main(credman: &mut impl CredmanApi) -> Result<(), Box<dyn std::
     };
     log::info!("Found {} protocol requests", protocol_requests.len());
 
-    for (i, pr) in protocol_requests.iter().enumerate() {
-        log::debug!("Processing request {}: protocol={}", i, pr.protocol);
-        if pr.protocol != "openid4vp-v1-unsigned" && pr.protocol != "openid4vp-v1-signed" {
-            log::warn!("Unsupported protocol: {}", pr.protocol);
-            continue;
+    for target_protocol in &registry.supported_protocols {
+        log::debug!("Matching requests for protocol={}", target_protocol);
+        for (i, pr) in protocol_requests.iter().enumerate() {
+            if pr.protocol != *target_protocol {
+                continue;
+            }
+            log::debug!("Processing request {}: protocol={}", i, pr.protocol);
+            if pr.protocol != "openid4vp-v1-unsigned" && pr.protocol != "openid4vp-v1-signed" {
+                log::warn!("Unsupported protocol: {}", pr.protocol);
+                continue;
+            }
+
+            let data_json = parse_protocol_request_data(pr)?;
+            let query = data_json.dcql_query.as_ref().ok_or("Missing dcql_query")?;
+            let match_result = crate::dcql::dcql_query(query, &registry);
+
+            let has_matches = !match_result.matched_credential_sets.is_empty()
+                || match_result.inline_issuance.is_some();
+            if has_matches {
+                // If there are multiple requests of the same preferred protocol,
+                // we only process the first request that yields a match.
+                report_match_result(credman, &match_result, i, &data_json, &matcher_data_buffer)?;
+                return Ok(());
+            }
         }
-
-        let data_json = parse_protocol_request_data(pr)?;
-        let query = data_json.dcql_query.as_ref().ok_or("Missing dcql_query")?;
-        let match_result = crate::dcql::dcql_query(query, &registry);
-
-        report_match_result(credman, &match_result, i, &data_json, &matcher_data_buffer)?;
     }
 
     log::info!("OpenID4VP matching process completed");
@@ -230,5 +243,63 @@ mod tests {
             registry_json.insert_str(pos, "\"metadata_display_text\": \"Verified Member\", ");
         }
         run_openid4vp_test("TC37_WasmMetadataText", Some(&registry_json));
+    }
+
+    /// Replaces the `"supported_protocols": [...]` array inside a JSON registry string
+    /// with the provided slice of protocol strings.
+    fn replace_supported_protocols(registry_json: &str, protocols: &[&str]) -> String {
+        let start_key = "\"supported_protocols\": [";
+        if let (Some(start_idx), Some(end_rel)) = (
+            registry_json.find(start_key),
+            registry_json.find(start_key).and_then(|idx| registry_json[idx..].find("],")),
+        ) {
+            let end_idx = start_idx + end_rel + 2;
+            let formatted_protocols = protocols
+                .iter()
+                .map(|p| format!("    \"{}\"", p))
+                .collect::<Vec<_>>()
+                .join(",\n");
+            let new_section = format!("\"supported_protocols\": [\n{}\n  ],", formatted_protocols);
+            let mut result = String::with_capacity(registry_json.len() + new_section.len());
+            result.push_str(&registry_json[..start_idx]);
+            result.push_str(&new_section);
+            result.push_str(&registry_json[end_idx..]);
+            result
+        } else {
+            registry_json.to_string()
+        }
+    }
+
+    #[test]
+    fn tc40_match_most_preferred_supported_protocol_available() {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let testdata_dir = std::path::PathBuf::from(manifest_dir).join("testdata");
+        let registry_json = std::fs::read_to_string(testdata_dir.join("registry.json")).unwrap();
+
+        // Inject custom supported_protocols preference order: signed then unsigned
+        let modified_registry = replace_supported_protocols(
+            &registry_json,
+            &["openid4vp-v1-signed", "openid4vp-v1-unsigned"],
+        );
+
+        run_openid4vp_test(
+            "TC40_MatchMostPreferredSupportedProtocolAvailable",
+            Some(&modified_registry),
+        );
+    }
+
+    #[test]
+    fn tc41_no_match_if_no_requests_for_supported_protocols() {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let testdata_dir = std::path::PathBuf::from(manifest_dir).join("testdata");
+        let registry_json = std::fs::read_to_string(testdata_dir.join("registry.json")).unwrap();
+
+        // Inject custom supported_protocols containing only "openid4vp-v1-signed"
+        let modified_registry = replace_supported_protocols(&registry_json, &["openid4vp-v1-signed"]);
+
+        run_openid4vp_test(
+            "TC41_NoMatchIfNoRequestsForSupportedProtocols",
+            Some(&modified_registry),
+        );
     }
 }

--- a/matcher-rs/src/openid4vp_models.rs
+++ b/matcher-rs/src/openid4vp_models.rs
@@ -44,6 +44,8 @@ pub struct DcqlCredentialSet {
 #[nserde(default)]
 pub struct Registry {
     pub credentials: RegistryCredentials,
+    #[nserde(default)]
+    pub supported_protocols: Vec<String>,
 }
 
 #[derive(DeJson, Debug, Clone, Default)]

--- a/matcher-rs/testdata/TC40_MatchMostPreferredSupportedProtocolAvailable_expected.json
+++ b/matcher-rs/testdata/TC40_MatchMostPreferredSupportedProtocolAvailable_expected.json
@@ -1,0 +1,139 @@
+{
+  "entrySets": {
+    "req:1;null": {
+      "entries": {
+        "0": {
+          "mdoc_cred_1": {
+            "additional_info": "",
+            "credId": "mdoc_cred_1",
+            "disclaimer": "",
+            "fields": [
+              [
+                "Family Name",
+                "Doe"
+              ],
+              [
+                "Given Name",
+                "John"
+              ],
+              [
+                "Age",
+                ""
+              ],
+              [
+                "Over 21",
+                "Yes"
+              ]
+            ],
+            "merchant_name": "",
+            "metadata_display_text": "",
+            "subtitle": "",
+            "title": "John's Driving License",
+            "transaction_amount": "",
+            "type": "Verification",
+            "warning": ""
+          },
+          "mdoc_cred_underage": {
+            "additional_info": "",
+            "credId": "mdoc_cred_underage",
+            "disclaimer": "",
+            "fields": [
+              [
+                "Age",
+                ""
+              ],
+              [
+                "Over 21",
+                "Yes"
+              ]
+            ],
+            "merchant_name": "",
+            "metadata_display_text": "",
+            "subtitle": "",
+            "title": "Underage License",
+            "transaction_amount": "",
+            "type": "Verification",
+            "warning": ""
+          },
+          "mdoc_cred_3": {
+            "additional_info": "",
+            "credId": "mdoc_cred_3",
+            "disclaimer": "",
+            "fields": [
+              [
+                "Family Name",
+                ""
+              ],
+              [
+                "Given Name",
+                ""
+              ],
+              [
+                "Age",
+                ""
+              ],
+              [
+                "Over 21",
+                ""
+              ]
+            ],
+            "merchant_name": "",
+            "metadata_display_text": "",
+            "subtitle": "",
+            "title": "Alice's Driving License",
+            "transaction_amount": "",
+            "type": "Verification",
+            "warning": ""
+          },
+          "mdoc_cred_4": {
+            "additional_info": "",
+            "credId": "mdoc_cred_4",
+            "disclaimer": "",
+            "fields": [
+              [
+                "Family Name",
+                ""
+              ],
+              [
+                "Given Name",
+                ""
+              ],
+              [
+                "Age",
+                ""
+              ],
+              [
+                "Over 21",
+                ""
+              ]
+            ],
+            "merchant_name": "",
+            "metadata_display_text": "",
+            "subtitle": "",
+            "title": "Jane's Driving License",
+            "transaction_amount": "",
+            "type": "Verification",
+            "warning": ""
+          }
+        }
+      },
+      "setId": "req:1;null",
+      "setLength": 1
+    }
+  },
+  "standaloneEntries": [
+    {
+      "additional_info": "",
+      "credId": "issuance_mdl_1",
+      "disclaimer": "",
+      "fields": [],
+      "merchant_name": "",
+      "metadata_display_text": "",
+      "subtitle": "From your local DMV",
+      "title": "Get a New mDL",
+      "transaction_amount": "",
+      "type": "InlineIssuance",
+      "warning": ""
+    }
+  ]
+}

--- a/matcher-rs/testdata/TC40_MatchMostPreferredSupportedProtocolAvailable_request.json
+++ b/matcher-rs/testdata/TC40_MatchMostPreferredSupportedProtocolAvailable_request.json
@@ -1,0 +1,32 @@
+{
+  "requests": [
+    {
+      "data": {
+        "dcql_query": {
+          "credentials": [
+            {
+              "format": "mso_mdoc",
+              "id": "mdl",
+              "meta": {
+                "doctype_value": "org.iso.18013.5.1.mDL"
+              }
+            }
+          ]
+        }
+      },
+      "protocol": "openid4vp-v1-unsigned"
+    },
+    {
+      "data": {
+        "request": "header.eyJkY3FsX3F1ZXJ5Ijp7ImNyZWRlbnRpYWxzIjpbeyJmb3JtYXQiOiJtc29fbWRvYyIsImlkIjoibWRsIiwibWV0YSI6eyJkb2N0eXBlX3ZhbHVlIjoib3JnLmlzby4xODAxMy41LjEubURMIn19XX19.signature"
+      },
+      "protocol": "openid4vp-v1-signed"
+    },
+    {
+      "data": {
+        "request": "header.eyJkY3FsX3F1ZXJ5Ijp7ImNyZWRlbnRpYWxzIjpbeyJmb3JtYXQiOiJtc29fbWRvYyIsImlkIjoibWRsIiwibWV0YSI6eyJkb2N0eXBlX3ZhbHVlIjoib3JnLmlzby4xODAxMy41LjEubURMIn19XX19.signature"
+      },
+      "protocol": "openid4vp-v1-signed"
+    }
+  ]
+}

--- a/matcher-rs/testdata/TC41_NoMatchIfNoRequestsForSupportedProtocols_expected.json
+++ b/matcher-rs/testdata/TC41_NoMatchIfNoRequestsForSupportedProtocols_expected.json
@@ -1,0 +1,4 @@
+{
+  "entrySets": {},
+  "standaloneEntries": []
+}

--- a/matcher-rs/testdata/TC41_NoMatchIfNoRequestsForSupportedProtocols_request.json
+++ b/matcher-rs/testdata/TC41_NoMatchIfNoRequestsForSupportedProtocols_request.json
@@ -1,0 +1,20 @@
+{
+  "requests": [
+    {
+      "data": {
+        "dcql_query": {
+          "credentials": [
+            {
+              "format": "mso_mdoc",
+              "id": "mdl",
+              "meta": {
+                "doctype_value": "org.iso.18013.5.1.mDL"
+              }
+            }
+          ]
+        }
+      },
+      "protocol": "openid4vp-v1-unsigned"
+    }
+  ]
+}


### PR DESCRIPTION
Port https://github.com/digitalcredentialsdev/CMWallet/pull/46 to Rust matcher

### Test Plan & Verification Evidence

#### Manual Test
1. Configured CMWallet app to use locally built AndroidX SDK with added `supportedProtocols` support.
2. Updated `CredentialRepository` with `supportedProtocols = listOf("openid4vp-v1-multisigned", "openid4vp-v1-signed")` when creating `OpenId4VpRegistry`.
3. Built and installed app.
4. Go to https://digital-credentials.dev/ in browser.
5. Request credentials with unsigned request.
6. Observe "Your info wasn't found".
7. Request credentials with signed request.
8. Verify that MDL was found and was able to be shared with RP.

#### Automated Unit Tests (`cargo test`)
Executed test suite execution inside `CMWallet/matcher-rs/`:
```
test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```