### PR TITLE
Enable DOM storage in issuance WebView

### DIFF
--- a/app/src/main/java/com/credman/cmwallet/createcred/CreateCredentialActivity.kt
+++ b/app/src/main/java/com/credman/cmwallet/createcred/CreateCredentialActivity.kt
@@ -294,6 +294,7 @@ class CreateCredentialActivity : ComponentActivity() {
                     WebView(it).apply {
                         clearCache(true)
                         settings.javaScriptEnabled = true
+                        settings.domStorageEnabled = true
                         this.layoutParams = ViewGroup.LayoutParams(
                             ViewGroup.LayoutParams.MATCH_PARENT,
                             ViewGroup.LayoutParams.MATCH_PARENT


### PR DESCRIPTION
**Purpose**
We are testing our OID4VCI API with this demo application, and the issuance WebView requires DOM storage for our SPA to load. 

**Testing**
- [x] enable Chrome's `chrome://flags/#web-identity-digital-credentials-creation` flag, initiate an OID4VCI offer through the DC API, use an Android phone with the CMWallet app to go through the Authorization flow in the WebView, save the credential in the Wallet.